### PR TITLE
docs: rewriting tests adr

### DIFF
--- a/adr-009.md
+++ b/adr-009.md
@@ -1,0 +1,47 @@
+---
+status: "proposed"
+date: "2025-10-06"
+decision-makers: Fernando Paris <fernando.paris@swirldslabs.com>, Mariusz Jasuwienas <mariusz.jasuwienas@arianelabs.com>, Michal Walczak <michal.walczak@arianelabs.com>, Piotr Swierzy <piotr.swierzy@arianelabs.com>
+consulted:
+informed:
+---
+
+ADR 009: Rewrite failing and resource-heavy tests
+
+## Context and problem statement
+
+Current tests fail for random reasons, rely on multiple pre-created accounts with high balances, take a long time to execute, and consume excessive local resources.
+We must decide whether to rewrite the test suite or keep it as is.
+
+## Considered options
+
+1. Rewrite the tests
+2. Keep the current tests as they are (recommended)
+
+## Option 1: Rewrite the tests
+
+## Consequences
+
+### Positive
+
+- Reliable, fast, and deterministic test runs.
+
+### Negative
+- Requires significant upfront rewrite effort.
+
+## Option 2: Keep the current tests as they are
+
+## Consequences
+
+### Positive
+
+ - No immediate development effort.
+ - We already fixed the tests so they are working correctly with hardhat 3
+
+### Negative
+
+- Continued random failures and high maintenance overhead.
+
+### Decision outcome
+
+We will use Option 2. This won’t require additional work at this stage of development.


### PR DESCRIPTION
Adds ADR 009 documenting the decision to keep the current test suite as is for now.
